### PR TITLE
Add missing index pages for tree structure representation in folders

### DIFF
--- a/docs/ActivePedal/Software/index.md
+++ b/docs/ActivePedal/Software/index.md
@@ -1,0 +1,9 @@
+# Simucube ActivePedal Software
+
+Please find all relevant content regarding how to configure the Simucube ActivePedal in Simucube Tuner.
+
+- [Effects](Effects.md)
+- [First use](First%20use.md)
+- [Input mapping](input%20mapping.md)
+- [Passive pedal setup](Passive%20pedal%20setup.md)
+- [Pedal feel](Pedal%20feel.md)

--- a/docs/Developers/ActivePedal/index.md
+++ b/docs/Developers/ActivePedal/index.md
@@ -1,0 +1,6 @@
+# ActivePedal
+
+Please find relevant technical information for the Simucube ActivePedal aimed at developers.
+
+- [API](API.md)
+- [Pinouts](Pinouts.md)

--- a/docs/Developers/index.md
+++ b/docs/Developers/index.md
@@ -1,0 +1,6 @@
+# Developers
+
+Please find content relevant for developers.
+
+- [ActivePedal](ActivePedal/index.md)
+- [Simucube Link](Simucube%20Link.md)


### PR DESCRIPTION
- Added missing index pages
    - `docs/ActivePedal/Software/index.md`
    - `docs/Developers/ActivePedal/index.md`
    - `docs/Developers/index.md`

The new pages have not been added to navigation. Mkdocs build outputs the following message:
```
INFO    -  The following pages exist in the docs directory, but are not included in the "nav" configuration:
             - ActivePedal/Software/index.md
             - Developers/index.md
             - Developers/ActivePedal/index.md
             - Developers/ActivePedal/API.md
```
